### PR TITLE
Fix/deputy not exiting on laptop

### DIFF
--- a/procman_ros/procman_ros/sheriff_cli.py
+++ b/procman_ros/procman_ros/sheriff_cli.py
@@ -36,6 +36,14 @@ class SheriffHeadless(ScriptListener):
             except AttributeError:
                 os.kill(self.spawned_deputy.pid, signal.SIGTERM)
                 self.spawned_deputy.wait()
+
+        # try to kill all child processes as well
+        try:
+            os.killpg(os.getpgid(self.spawned_deputy.pid), signal.SIGKILL)
+            print("killed child processes for local deputy")
+        except:
+            pass
+
         self.spawned_deputy = None
         self.sheriff.shutdown()
         self.script_manager.shutdown()

--- a/procman_ros/procman_ros/sheriff_gtk/sheriff_gtk.py
+++ b/procman_ros/procman_ros/sheriff_gtk/sheriff_gtk.py
@@ -326,6 +326,14 @@ class SheriffGtk(SheriffListener):
             except AttributeError:  # python 2.4, 2.5 don't have Popen.terminate()
                 os.kill(self.spawned_deputy.pid, signal.SIGTERM)
                 self.spawned_deputy.wait()
+
+        # try to kill all child processes as well
+        try:
+            os.killpg(os.getpgid(self.spawned_deputy.pid), signal.SIGKILL)
+            print("killed child processes for local deputy")
+        except:
+            pass
+
         self.spawned_deputy = None
 
     def _check_spawned_deputy(self):


### PR DESCRIPTION
Fix bug where the deputy often doesn't exit properly when running in offline mode. It does this by making sheriff kill the children of the deputy, as well as the deputy itself.

This should only affect operation when we run the sheriff manually with the `ros2 run procman_ros sheriff procman.pmd` command.