### PR TITLE
fix rare bug that causes procman_ros to crash on startup.

### DIFF
--- a/procman_ros/procman_ros/sheriff.py
+++ b/procman_ros/procman_ros/sheriff.py
@@ -780,7 +780,11 @@ class Sheriff:
         if not command_id:
             raise ValueError("Invalid command id {}".format(command_id))
         if self._get_command(command_id):
-            raise ValueError("Duplicate command id {}".format(command_id))
+            # don't throw for this error.
+            # this can happen if the deputy reports a command before the
+            # sheriff has a chance to add it from config_file.
+            print("WARN: Duplicate command id {}".format(command_id))
+            # raise ValueError("Duplicate command id {}".format(command_id))
         if not deputy_id:
             raise ValueError("Invalid deputy {}".format(deputy_id))
 

--- a/procman_ros/procman_ros/sheriff.py
+++ b/procman_ros/procman_ros/sheriff.py
@@ -567,6 +567,19 @@ class Sheriff:
 
     def __init__(self, nh):
         """Initialize a new Sheriff object"""
+
+        # initialize objects before we start subscribers and worker threads
+        self._exiting = False
+        self._lock = threading.Lock()
+        self._condvar = threading.Condition(self._lock)
+
+        self._deputies = {}
+        self._is_observer = False
+        self._id = platform.node() + ":" + str(os.getpid()) + ":" + str(_now_utime())
+
+        self._listeners = []
+        self._queued_events = []
+
         self.nh = nh
 
         self._prev_can_reach_master = True
@@ -584,10 +597,6 @@ class Sheriff:
         self.discover_pub = self.nh.create_publisher(
             ProcmanDiscovery, "/procman/discover", 10)
 
-        self._deputies = {}
-        self._is_observer = False
-        self._id = platform.node() + ":" + str(os.getpid()) + ":" + str(_now_utime())
-
         # publish a discovery message to query for existing deputies
         discover_msg = ProcmanDiscovery()
         discover_msg.timestamp = self.nh.get_clock().now().to_msg()
@@ -597,18 +606,12 @@ class Sheriff:
 
         # Create a worker thread for periodically publishing orders
         self._worker_thread_obj = threading.Thread(target=self._worker_thread)
-        self._exiting = False
-        self._lock = threading.Lock()
-        self._condvar = threading.Condition(self._lock)
         self._worker_thread_obj.start()
 
         # no roscore in ros2
         # self._master_reach_check_thread = threading.Thread(
         #     target=self._master_reach_check)
         # self._master_reach_check_thread.start()
-
-        self._listeners = []
-        self._queued_events = []
 
     def _get_or_make_deputy(self, deputy_id):
         # _lock should already be acquired


### PR DESCRIPTION
Fix subtle and rare bug that can cause the sheriff to fail during startup.

The fix is just move variable initialisation to before the subscribers / worker thread.

This is a race condition where the subscribers were created before we initialise some variables in the constructor. The error we get in thor was:

```
received pmd info from [localhost]
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/ros/humble/lib/python3.8/site-packages/rclpy/__init__.py", line 222, in spin
    executor.spin_once()
  File "/opt/ros/humble/lib/python3.8/site-packages/rclpy/executors.py", line 739, in spin_once
    self._spin_once_impl(timeout_sec)
  File "/opt/ros/humble/lib/python3.8/site-packages/rclpy/executors.py", line 736, in _spin_once_impl
    raise handler.exception()
  File "/opt/ros/humble/lib/python3.8/site-packages/rclpy/task.py", line 239, in __call__
    self._handler.send(None)
  File "/opt/ros/humble/lib/python3.8/site-packages/rclpy/executors.py", line 437, in handler
    await call_coroutine(entity, arg)
  File "/opt/ros/humble/lib/python3.8/site-packages/rclpy/executors.py", line 362, in _execute_subscription
    await await_or_execute(sub.callback, msg)
  File "/opt/ros/humble/lib/python3.8/site-packages/rclpy/executors.py", line 107, in await_or_execute
    return callback(*args)
  File "/home/radius/ros2_ws/install/procman_ros/lib/python3.8/site-packages/procman_ros/sheriff.py", line 708, in _on_pmd_info
    with self._lock:
AttributeError: 'Sheriff' object has no attribute '_lock'
Running script online_vilens_and_slam
```
